### PR TITLE
Typo corrections Update features.mdx

### DIFF
--- a/academy/try-remix/features.mdx
+++ b/academy/try-remix/features.mdx
@@ -6,7 +6,7 @@ The editor pane loads with the Remix home screen, which contains useful guides a
 
 ![Try Remix 1](./img/editor-pane.png)
 
-You can edit your code under the editor pane, which will consist of features such as syntax and error highlighting. Do note that errors are highlighted with exclaimation marks next to the line number where the error is occurring.
+You can edit your code under the editor pane, which will consist of features such as syntax and error highlighting. Do note that errors are highlighted with exclamation marks next to the line number where the error is occurring.
 
 ##  Terminal Output
 


### PR DESCRIPTION
The text contains a typographical error in the phrase "exclaimation marks." The correct spelling is "exclamation marks."

### Description of the Error:
- **Original**: "Do note that errors are highlighted with exclaimation marks next to the line number where the error is occurring."
- **Corrected**: "Do note that errors are highlighted with **exclamation** marks next to the line number where the error is occurring."

### Explanation:
The misspelling "exclaimation" is an incorrect formation of the word "exclamation," which refers to a mark used to indicate strong feelings or a high volume (e.g., an exclamation point). This typographical error could lead to confusion for readers who may not recognize the misspelled term, potentially impacting the clarity of the instructions provided in the document.